### PR TITLE
Guarantee verifiability of jwt-vc

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,8 @@
 VITE_GLOBAL_BACKEND_URL=
 VITE_DIRECT_BACKEND_URL=http://localhost:8080
 VITE_PUBLIC_TEZOS_RPC_URL=https://ghostnet.ecadinfra.com/
+# Network is mandatory in did construction (here: ghostnet)
+VITE_CAIP2_TEZOS_NETWORK=NetXnHfVqm9iesp
 
 # BACKEND
 # Insert ngrok url here
@@ -19,4 +21,3 @@ AUTH_SECRET=somereallysecretsecret
 TEZOS_RPC_URL=https://ghostnet.ecadinfra.com/
 # Insert address of the deployed registry contract
 TEZOS_REGISTRY_CONTRACT=
-

--- a/frontend/src/components/table/display-application-menu.tsx
+++ b/frontend/src/components/table/display-application-menu.tsx
@@ -94,10 +94,10 @@ export const DisplayApplicationMenu = ({
         console.log("Credential issued:", credential);
         // we know that our use DIDs are pkh:tezos, so we can just split
         const credentialPayload = {
-          holder_pkh: credential.payload.sub.split(":")[3],
+          holder_pkh: credential.payload.sub.split(":")[4],
           subject: credential.payload.sub,
           issuer: credential.payload.iss,
-          issuer_pkh: credential.payload.iss.split(":")[3],
+          issuer_pkh: credential.payload.iss.split(":")[4],
           name: credential.payload.vc.credentialSubject["gx:legalName"],
           format,
           credential: credential,

--- a/frontend/src/hooks/use-issue-credential.ts
+++ b/frontend/src/hooks/use-issue-credential.ts
@@ -11,6 +11,8 @@ import { useState } from "react";
 import { Application } from "@/model/application";
 import { payloadBytesFromString } from "@/lib/utils";
 
+const tezosNetworkId = import.meta.env.VITE_CAIP2_TEZOS_NETWORK;
+
 type IssueCredential = {
   issueCredential: (
     application: Application,
@@ -34,8 +36,12 @@ export function useIssueCredential(): IssueCredential {
     setError(null);
     try {
       const account = await dAppClient?.getActiveAccount();
-      const did = `did:pkh:tezos:` + account?.address;
-      const rawCredential = await constructPayload(application, type, did);
+      if (!account || !account.publicKey) {
+        throw new Error("No account connected");
+      }
+      const pk = account.publicKey;
+      const did = `did:pkh:tezos:${tezosNetworkId}:${account?.address}`;
+      const rawCredential = await constructPayload(application, type, did, pk);
       return await issue(rawCredential, dAppClient);
     } catch (err) {
       setError(err instanceof Error ? err : new Error("Unknown error"));
@@ -49,7 +55,8 @@ export function useIssueCredential(): IssueCredential {
   const constructPayload = async (
     application: Application,
     type: "employee" | "company",
-    did: string
+    did: string,
+    pk: string
   ) => {
     const date = new Date();
     const iat = Math.floor(date.getTime() / 1000);
@@ -68,8 +75,8 @@ export function useIssueCredential(): IssueCredential {
       iss: did,
       iat: iat,
       nbf: iat,
-      sub: `did:pkh:tezos:` + application?.pkh,
-      jti: "urn:uuid:" + crypto.randomUUID(),
+      sub: `did:pkh:tezos:${tezosNetworkId}:${application?.pkh}`,
+      jti: `urn:uuid:${crypto.randomUUID()}`,
     };
     let additionalPayload;
     if (type == "company") {
@@ -92,7 +99,8 @@ export function useIssueCredential(): IssueCredential {
     const jwtHeader = {
       alg: "EdDSA",
       typ: "JWT",
-      kid: did,
+      // not using the did here because otherwise a verifier would have no guaranteed way of getting the pk
+      kid: pk,
     };
     const totalPayload =
       base64url.encode(JSON.stringify(jwtHeader)) +


### PR DESCRIPTION
In the previous version, the did was directly used as kid. If the address has not previously transacted, there is no way to get the public key from that, making the VC not verifiable.