### PR TITLE
Avoid reconstruction of JWT

### DIFF
--- a/backend/controllers/takeout.controller.ts
+++ b/backend/controllers/takeout.controller.ts
@@ -1,6 +1,5 @@
 import { Request, Response } from "express";
 import { CredentialRepository } from "../repositories/credential";
-import { base64url } from "jose";
 
 export const TakeoutController = {
   wellKnownIssuer: async (req: Request, res: Response): Promise<void> => {
@@ -85,15 +84,13 @@ export const TakeoutController = {
       }
 
       const credential = await CredentialRepository.get(id);
-      const encodedCredential =
-        base64url.encode(JSON.stringify(credential?.credential.header)) +
-        "." +
-        base64url.encode(JSON.stringify(credential?.credential.payload)) +
-        "." +
-        credential?.credential.signature;
+      if (!credential) {
+        res.status(400).json({ message: "Credential not found" });
+        return;
+      }
 
-      console.log(encodedCredential);
-      res.status(200).json({ credential: encodedCredential });
+      console.log(credential.jwt);
+      res.status(200).json({ credential: credential.jwt });
     } catch (error) {
       console.error("Error fetching credential by ID:", error);
       res.status(500).json({ message: "Internal server error" });

--- a/backend/db/migrations.ts
+++ b/backend/db/migrations.ts
@@ -49,6 +49,7 @@ async function up(db: Kysely<any>): Promise<void> {
     .addColumn("id", "uuid", col =>
       col.primaryKey().defaultTo(sql`gen_random_uuid()`)
     )
+    .addColumn("jwt", "varchar", col => col.notNull())
     .addColumn("holder_pkh", "varchar", col => col.notNull())
     .addColumn("issuer_pkh", "varchar", col => col.notNull())
     .addColumn("subject", "varchar", col => col.notNull())
@@ -76,6 +77,7 @@ async function up(db: Kysely<any>): Promise<void> {
     .addColumn("id", "uuid", col =>
       col.primaryKey().defaultTo(sql`gen_random_uuid()`)
     )
+    .addColumn("jwt", "varchar", col => col.notNull())
     .addColumn("holder_pkh", "varchar", col => col.notNull())
     .addColumn("issuer_pkh", "varchar", col => col.notNull())
     .addColumn("subject", "varchar", col => col.notNull())

--- a/backend/db/schema.ts
+++ b/backend/db/schema.ts
@@ -24,11 +24,12 @@ interface BaseApplication {
 
 interface BaseCredential {
   id: Generated<string>; // UUID
+  jwt: string; // full jwt serialization
   holder_pkh: string;
   issuer_pkh: string;
   subject: string;
   issuer: string;
-  name: string; // humand-readable name of the subject
+  name: string; // human-readable name of the subject
   format: CredentialFormat;
   revoked: boolean;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -17,7 +17,6 @@
         "express": "^4.21.2",
         "express-session": "^1.18.1",
         "http-errors": "~1.6.3",
-        "jose": "^6.0.8",
         "jsonwebtoken": "^9.0.2",
         "kysely": "^0.27.5",
         "lodash": "^4.17.21",
@@ -4368,14 +4367,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/jose": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.0.8.tgz",
-      "integrity": "sha512-EyUPtOKyTYq+iMOszO42eobQllaIjJnwkZ2U93aJzNyPibCy7CEvT9UQnaCVB51IAd49gbNdCew1c0LcLTCB2g==",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,7 +18,6 @@
     "express": "^4.21.2",
     "express-session": "^1.18.1",
     "http-errors": "~1.6.3",
-    "jose": "^6.0.8",
     "jsonwebtoken": "^9.0.2",
     "kysely": "^0.27.5",
     "lodash": "^4.17.21",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gx-credentials-backend",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gx-credentials-frontend",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite --port 3000",

--- a/frontend/src/components/table/display-application-menu.tsx
+++ b/frontend/src/components/table/display-application-menu.tsx
@@ -3,6 +3,7 @@
 import { DotsHorizontalIcon } from "@radix-ui/react-icons";
 import { Row } from "@tanstack/react-table";
 import React from "react";
+import { base64url } from "jose";
 
 import ApplicationFormDisplay from "./view-application";
 
@@ -80,20 +81,32 @@ export const DisplayApplicationMenu = ({
 
       // Only attempt credential issuance for accepted applications
       if (status === ApplicationStatus.Accepted && format) {
-        const credential = (await issueCredential(
+        const credentialJWT = (await issueCredential(
           row.original as Application,
           credentialType,
           dAppClient
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
         )) as any; // Credential
 
-        if (!credential) {
+        if (!credentialJWT) {
           throw new Error("Failed to issue credential.");
         }
+
+        const [header, vcPayload, signature] = credentialJWT.split(".");
+        const credential = {
+          header: JSON.parse(
+            Buffer.from(base64url.decode(header)).toString("utf-8")
+          ),
+          payload: JSON.parse(
+            Buffer.from(base64url.decode(vcPayload)).toString("utf-8")
+          ),
+          signature: Buffer.from(base64url.decode(signature)).toString("utf-8"),
+        };
 
         console.log("Credential issued:", credential);
         // we know that our use DIDs are pkh:tezos, so we can just split
         const credentialPayload = {
+          jwt: credentialJWT,
           holder_pkh: credential.payload.sub.split(":")[4],
           subject: credential.payload.sub,
           issuer: credential.payload.iss,

--- a/frontend/src/hooks/use-issue-credential.ts
+++ b/frontend/src/hooks/use-issue-credential.ts
@@ -113,7 +113,6 @@ export function useIssueCredential(): IssueCredential {
     rawCredentialString: string,
     dAppClient: DAppClient
   ): Promise<unknown> => {
-    let credentialString = "";
     const account = await dAppClient?.getActiveAccount();
     console.log("Generating credential...");
     console.log("account", account);
@@ -136,19 +135,7 @@ export function useIssueCredential(): IssueCredential {
     console.log(response);
     console.log("jwtvc", jwtvc);
 
-    const [header, vcPayload, signature] = jwtvc.split(".");
-    credentialString = JSON.stringify({
-      header: JSON.parse(
-        Buffer.from(base64url.decode(header)).toString("utf-8")
-      ),
-      payload: JSON.parse(
-        Buffer.from(base64url.decode(vcPayload)).toString("utf-8")
-      ),
-      signature,
-    });
-    console.log("JWT credential string", credentialString);
-
-    return JSON.parse(credentialString);
+    return jwtvc;
   };
 
   return {

--- a/frontend/src/types/session.ts
+++ b/frontend/src/types/session.ts
@@ -1,5 +1,6 @@
 export interface CredentialEntry {
   id: string; // UUID
+  jwt: string;
   holder_pkh: string;
   issuer_pkh: string;
   subject: string;


### PR DESCRIPTION
If the JWT is parsed and then stringified and encoded again, that can lead to differences from the version that was signed, making the signature useless.